### PR TITLE
Avoid "unsupported protocol" error for relative URLs

### DIFF
--- a/bin/swagmap.bundle.js
+++ b/bin/swagmap.bundle.js
@@ -37422,6 +37422,12 @@ TinCan client library
       if (this._request) {
         throw new InvalidStateError("send() already called");
       }
+
+      // Default to current protocol for relative URLs
+      if (this._url.protocol === null) {
+        this._url.protocol = window.location.protocol;
+      }
+
       switch (this._url.protocol) {
         case 'file:':
           this._sendFile(data);


### PR DESCRIPTION
This might not actually go in the 'bundle' file, but here's what's going on: as-is, if the xapi endpoint is a relative url like `/xapi`, swagmap throws an Unsupported Protocol exception because it just checks the url for a protocol value. Being able to use a relative url here is good because it's one fewer places where we need to specify an explicit IP, and it allows us to serve the site from multiple IPs (e.g. from a WAP interface and a wired interface) without problems. 

This patch falls back on `window.location.protocol` if the given URL's protocol is null (so if someone did, for some reason, actually specify an ftp:// url or something, the exception would still get thrown.  
